### PR TITLE
Add repo spec for building Ciera using Maile Technical packages

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -50,6 +50,22 @@
       <url>https://maven.pkg.github.com/mailetechnical/ciera</url>
     </repository>
   </distributionManagement>
+  <repositories>
+    <repository>
+      <id>github</id>
+      <url>https://maven.pkg.github.com/mailetechnical/*</url>
+      <releases><enabled>true</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>github</id>
+      <url>https://maven.pkg.github.com/mailetechnical/*</url>
+      <releases><enabled>true</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
+    </pluginRepository>
+  </pluginRepositories>
   <profiles>
     <profile>
       <id>release</id>


### PR DESCRIPTION
This commit adds repository specifications for plug-ins and dependencies
so that Ciera can be built using the Maile Technical packages published
on Github.
I've tested this by building a 2.5.1-SNAPSHOT that is equivalent to the 2.5.0 release.  I then used that snapshot to compile Carpark.
Alasdar, please test this branch to ensure it works for you, and assuming it does, please service this pull request to merge the branch into the Maile Technical master.