### PR TITLE
Added project encoding set

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/src/runtime/.settings/org.eclipse.core.resources.prefs
+++ b/src/runtime/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/src/tool-core/.settings/org.eclipse.core.resources.prefs
+++ b/src/tool-core/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/src/tool-sql/.settings/org.eclipse.core.resources.prefs
+++ b/src/tool-sql/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/src/tool-template/.settings/org.eclipse.core.resources.prefs
+++ b/src/tool-template/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
The newer version of Eclipse issues a warning about projects that do not have an explicit encoding set.